### PR TITLE
Exclude WebRequestExtensions class from builds where it has no methods

### DIFF
--- a/Rackspace.Threading/WebRequestExtensions.cs
+++ b/Rackspace.Threading/WebRequestExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Rackspace, US Inc. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+#if !PORTABLE || !NET45PLUS
+
 namespace Rackspace.Threading
 {
     using System;
@@ -173,3 +175,5 @@ namespace Rackspace.Threading
 #endif
     }
 }
+
+#endif


### PR DESCRIPTION
The **netcore45** documentation output is not including proper information about the `WebRequestExtensions` class. This change excludes the class from the **netcore45** project, leaving its information to be properly included by the Version Builder plug-in.

Since this issue only affected the documentation build, the published documentation for **1.0.0-beta002** was built with this patch in place, even though the tagged commit for that release did not include it.
