### PR TITLE
Validate strong name keys prior to creating NuGet packages

### DIFF
--- a/Build/build.ps1
+++ b/Build/build.ps1
@@ -1,6 +1,7 @@
 param (
 	[switch]$Debug,
-	[string]$VisualStudioVersion = "12.0"
+	[string]$VisualStudioVersion = "12.0",
+	[switch]$SkipKeyCheck
 )
 
 # build the solution
@@ -27,6 +28,20 @@ $msbuild = "$env:windir\Microsoft.NET\Framework64\v4.0.30319\msbuild.exe"
 if ($LASTEXITCODE -ne 0) {
 	echo "Build failed, aborting!"
 	exit $p.ExitCode
+}
+
+# By default, do not create a NuGet package unless the expected strong name key files were used
+if (-not $SkipKeyCheck) {
+	. .\keys.ps1
+
+	foreach ($pair in $Keys.GetEnumerator()) {
+		$assembly = Resolve-FullPath -Path "..\Rackspace.Threading\bin\$($pair.Key)\$BuildConfig\Rackspace.Threading.dll"
+		# Run the actual check in a separate process or the current process will keep the assembly file locked
+		powershell -Command ".\check-key.ps1 -Assembly '$assembly' -ExpectedKey '$($pair.Value)' -Build '$($pair.Key)'"
+		if ($LASTEXITCODE -ne 0) {
+			Exit $p.ExitCode
+		}
+	}
 }
 
 if (-not (Test-Path 'nuget')) {

--- a/Build/check-key.ps1
+++ b/Build/check-key.ps1
@@ -1,0 +1,31 @@
+param(
+	[string]$Assembly,
+	[string]$ExpectedKey,
+	[string]$Build = $null
+)
+
+function Get-PublicKeyToken() {
+	param([string]$assembly = $null)
+	if ($assembly) {
+		$bytes = $null
+		$bytes = [System.Reflection.Assembly]::ReflectionOnlyLoadFrom($assembly).GetName().GetPublicKeyToken()
+		if ($bytes) {
+			$key = ""
+			for ($i=0; $i -lt $bytes.Length; $i++) {
+				$key += "{0:x2}" -f $bytes[$i]
+			}
+
+			$key
+		}
+	}
+}
+
+if (-not $Build) {
+	$Build = $Assembly
+}
+
+$actual = Get-PublicKeyToken -assembly $Assembly
+if ($actual -ne $ExpectedKey) {
+	$host.ui.WriteErrorLine("Invalid publicKeyToken for '$Build'; expected '$ExpectedKey' but found '$actual'")
+	exit 1
+}

--- a/Build/keys.ps1
+++ b/Build/keys.ps1
@@ -1,0 +1,14 @@
+# Note: these values may only change during minor release
+$Keys = @{
+	'net35-client' = '8b3790928cb57ea0'
+	'net40-client' = 'b3a60e8d525c0432'
+	'net45' = 'c5149d599dccb791'
+	'netcore45' = 'c0beeaaf4ff18c32'
+	'portable-net40' = '165cb04bbaa60d42'
+	'portable-net45' = '7c9e9383f8e98b3a'
+}
+
+function Resolve-FullPath() {
+	param([string]$Path)
+	[System.IO.Path]::GetFullPath((Join-Path (pwd) $Path))
+}


### PR DESCRIPTION
Fixes #42
- The check is performed in **build.ps1** instead of **push.ps1**
- The check can be skipped by including the `-SkipKeyCheck` argument to **build.ps1**
