### PR TITLE
Generate XML documentation for test projects

### DIFF
--- a/Tests/UnitTest.RackspaceThreading/UnitTest.RackspaceThreading.net35-client.csproj
+++ b/Tests/UnitTest.RackspaceThreading/UnitTest.RackspaceThreading.net35-client.csproj
@@ -28,6 +28,8 @@
     <DefineConstants>DEBUG;TRACE;NET35;NET35PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\net35-client\Debug\UnitTest.RackspaceThreading.net35.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,6 +38,8 @@
     <DefineConstants>TRACE;NET35;NET35PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\net35-client\Release\UnitTest.RackspaceThreading.net35.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Tests/UnitTest.RackspaceThreading/UnitTest.RackspaceThreading.net40-client.csproj
+++ b/Tests/UnitTest.RackspaceThreading/UnitTest.RackspaceThreading.net40-client.csproj
@@ -28,6 +28,8 @@
     <DefineConstants>DEBUG;TRACE;NET40;NET40PLUS;NET35PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\net40-client\Debug\UnitTest.RackspaceThreading.net40.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,6 +38,8 @@
     <DefineConstants>TRACE;NET40;NET40PLUS;NET35PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\net40-client\Release\UnitTest.RackspaceThreading.net40.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Tests/UnitTest.RackspaceThreading/UnitTest.RackspaceThreading.net45.csproj
+++ b/Tests/UnitTest.RackspaceThreading/UnitTest.RackspaceThreading.net45.csproj
@@ -28,6 +28,8 @@
     <DefineConstants>DEBUG;TRACE;NET45;NET45PLUS;NET40PLUS;NET35PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\net45\Debug\UnitTest.RackspaceThreading.net45.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,6 +38,8 @@
     <DefineConstants>TRACE;NET45;NET45PLUS;NET40PLUS;NET35PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\net45\Release\UnitTest.RackspaceThreading.net45.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Tests/UnitTest.RackspaceThreading/UnitTest.RackspaceThreading.portable-net40.csproj
+++ b/Tests/UnitTest.RackspaceThreading/UnitTest.RackspaceThreading.portable-net40.csproj
@@ -28,6 +28,8 @@
     <DefineConstants>DEBUG;TRACE;PORTABLE;NET40;NET40PLUS;NET35PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\portable-net40\Debug\UnitTest.RackspaceThreading.portable_net40.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,6 +38,8 @@
     <DefineConstants>TRACE;PORTABLE;NET40;NET40PLUS;NET35PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\portable-net40\Release\UnitTest.RackspaceThreading.portable_net40.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Tests/UnitTest.RackspaceThreading/UnitTest.RackspaceThreading.portable-net45.csproj
+++ b/Tests/UnitTest.RackspaceThreading/UnitTest.RackspaceThreading.portable-net45.csproj
@@ -28,6 +28,8 @@
     <DefineConstants>DEBUG;TRACE;PORTABLE;NET45;NET45PLUS;NET40PLUS;NET35PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\portable-net45\Debug\UnitTest.RackspaceThreading.portable_net45.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,6 +38,8 @@
     <DefineConstants>TRACE;PORTABLE;NET45;NET45PLUS;NET40PLUS;NET35PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\portable-net45\Release\UnitTest.RackspaceThreading.portable_net45.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">


### PR DESCRIPTION
Roslyn does not perform the following actions unless XML documentation is enabled as part of the build:
- Validate the syntax of `<see cref="..."/>` references
- Consider usages of types in `cref="..."` documentation elements for the purposes of removing unused `using` declarations
