### PR TITLE
Simplifications

### DIFF
--- a/Rackspace.Threading/CompletedTask.cs
+++ b/Rackspace.Threading/CompletedTask.cs
@@ -64,7 +64,7 @@ namespace Rackspace.Threading
 
             static CompletedTaskHolder()
             {
-                Default = CompletedTaskHolder<object>.Default;
+                Default = CompletedTaskHolder<VoidResult>.Default;
             }
         }
 
@@ -90,7 +90,7 @@ namespace Rackspace.Threading
 
             static CanceledTaskHolder()
             {
-                Default = CanceledTaskHolder<object>.Default;
+                Default = CanceledTaskHolder<VoidResult>.Default;
             }
         }
 


### PR DESCRIPTION
- Use new .NET 4.5 methods to implement `CompletedTask` methods, when available
- Use `VoidResult` instead of `object` where appropriate
