### PR TITLE
Stream tweaks

### DIFF
--- a/Rackspace.Threading/StreamExtensions.cs
+++ b/Rackspace.Threading/StreamExtensions.cs
@@ -341,6 +341,12 @@ namespace Rackspace.Threading
         /// <exception cref="InvalidOperationException">If <paramref name="stream"/> is currently in use by a previous write operation.</exception>
         public static Task WriteAsync(this Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
+            if (stream == null)
+                throw new ArgumentNullException("stream");
+
+            if (cancellationToken.IsCancellationRequested)
+                return CompletedTask.Canceled();
+
             return Task.Factory.FromAsync(stream.BeginWrite, stream.EndWrite, buffer, offset, count, null);
         }
     }


### PR DESCRIPTION
- Make sure `FlushAsync` executes the flush operation on the default task scheduler
- Throw the expected `ArgumentNullException` instead of `NullReferenceException` if the stream is null in `WriteAsync`
- Check the `CancellationToken` in `WriteAsync`
