### PR TITLE
Remove CompletedTask caching

### DIFF
--- a/Rackspace.Threading/CompletedTask.cs
+++ b/Rackspace.Threading/CompletedTask.cs
@@ -18,7 +18,7 @@ namespace Rackspace.Threading
         {
             get
             {
-                return CompletedTaskHolder.Default;
+                return FromResult(default(VoidResult));
             }
         }
 
@@ -45,7 +45,7 @@ namespace Rackspace.Threading
         /// <returns>A canceled <see cref="Task"/>.</returns>
         public static Task Canceled()
         {
-            return CanceledTaskHolder.Default;
+            return Canceled<VoidResult>();
         }
 
         /// <summary>
@@ -55,55 +55,9 @@ namespace Rackspace.Threading
         /// <returns>A canceled <see cref="Task{TResult}"/>.</returns>
         public static Task<TResult> Canceled<TResult>()
         {
-            return CanceledTaskHolder<TResult>.Default;
-        }
-
-        private static class CompletedTaskHolder
-        {
-            public static readonly Task Default;
-
-            static CompletedTaskHolder()
-            {
-                Default = CompletedTaskHolder<VoidResult>.Default;
-            }
-        }
-
-        private static class CompletedTaskHolder<T>
-        {
-            public static readonly Task<T> Default;
-
-            static CompletedTaskHolder()
-            {
-#if NET45PLUS
-                Default = Task.FromResult(default(T));
-#else
-                TaskCompletionSource<T> completionSource = new TaskCompletionSource<T>();
-                completionSource.SetResult(default(T));
-                Default = completionSource.Task;
-#endif
-            }
-        }
-
-        private static class CanceledTaskHolder
-        {
-            public static readonly Task Default;
-
-            static CanceledTaskHolder()
-            {
-                Default = CanceledTaskHolder<VoidResult>.Default;
-            }
-        }
-
-        private static class CanceledTaskHolder<T>
-        {
-            public static readonly Task<T> Default;
-
-            static CanceledTaskHolder()
-            {
-                TaskCompletionSource<T> completionSource = new TaskCompletionSource<T>();
-                completionSource.SetCanceled();
-                Default = completionSource.Task;
-            }
+            TaskCompletionSource<TResult> completionSource = new TaskCompletionSource<TResult>();
+            completionSource.SetCanceled();
+            return completionSource.Task;
         }
     }
 }

--- a/Tests/UnitTest.RackspaceThreading/TestCompletedTask.cs
+++ b/Tests/UnitTest.RackspaceThreading/TestCompletedTask.cs
@@ -41,6 +41,16 @@ namespace UnitTest.RackspaceThreading
         }
 
         [TestMethod]
+        public void TestCancelledGetsDisposed()
+        {
+            CompletedTask.Canceled().Dispose();
+            TestCancelled();
+
+            Assert.IsTrue(CompletedTask.Canceled().Select(_ => default(object)).IsCanceled);
+            Assert.IsTrue(CoreTaskExtensions.Then(CompletedTask.Canceled(), _ => CompletedTask.Default).IsCanceled);
+        }
+
+        [TestMethod]
         public void TestCancelledT()
         {
             Task<int> cancelledTask = CompletedTask.Canceled<int>();
@@ -71,6 +81,16 @@ namespace UnitTest.RackspaceThreading
         }
 
         [TestMethod]
+        public void TestCancelledTGetsDisposed()
+        {
+            CompletedTask.Canceled<int>().Dispose();
+            TestCancelledT();
+
+            Assert.IsTrue(CompletedTask.Canceled<int>().Select(_ => default(object)).IsCanceled);
+            Assert.IsTrue(CoreTaskExtensions.Then(CompletedTask.Canceled<int>(), _ => CompletedTask.Default).IsCanceled);
+        }
+
+        [TestMethod]
         public void TestDefault()
         {
             Task completedTask = CompletedTask.Default;
@@ -80,6 +100,16 @@ namespace UnitTest.RackspaceThreading
             Stopwatch timer = Stopwatch.StartNew();
             Task.WaitAll(new[] { completedTask });
             Assert.IsTrue(timer.Elapsed <= TimeSpan.FromMilliseconds(5), "Waiting on CompletedTask.Default resulted in an unexpected delay ({0}ms > 5ms)", timer.Elapsed.TotalMilliseconds);
+        }
+
+        [TestMethod]
+        public void TestDefaultGetsDisposed()
+        {
+            CompletedTask.Default.Dispose();
+            TestDefault();
+
+            Assert.IsTrue(CompletedTask.Default.Select(_ => default(object)).IsCompleted);
+            Assert.IsTrue(CoreTaskExtensions.Then(CompletedTask.Default, _ => CompletedTask.Default).IsCompleted);
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes #63 by preventing code from reusing `Task` instances.
