### PR TITLE
Remove unreachable code block

### DIFF
--- a/Rackspace.Threading/TaskBlocks.cs
+++ b/Rackspace.Threading/TaskBlocks.cs
@@ -248,12 +248,6 @@ namespace Rackspace.Threading
             continuation =
                 previousTask =>
                 {
-                    if (previousTask.Status != TaskStatus.RanToCompletion)
-                    {
-                        taskCompletionSource.SetFromFailedTask(previousTask);
-                        return;
-                    }
-
                     if (!condition())
                     {
                         taskCompletionSource.SetResult(default(VoidResult));


### PR DESCRIPTION
The code is unreachable because the overload of `Select` used by this implementation does not call the continuation function unless the antecedent ran to completion.
